### PR TITLE
Fixed bug with not being able to arrow down from the top element

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -62,7 +62,7 @@ const CanopySelect = React.createClass({
 
 			this.setState({
 				dialogDisplayed: true,
-				selectedIndex: !selectedIndex ? 0 : selectedIndex - 1
+				selectedIndex: selectedIndex === undefined ? 0 : selectedIndex - 1
 			});
 
 			//positionDialog(scope.collection[scope.selectedIndex]);


### PR DESCRIPTION
If selectedIndex is 0, then
    !selectedIndex ? 0 : selectedIndex - 1
will always be 0. This means that you are stuck on the top element and you can't arrow down.