### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "node node_modules/karma/bin/karma start",
     "dist": "webpack --optimize-minimize",
-		"compile": "node node_modules/babel/bin/babel.js src --out-dir lib",
-		"build": "npm run dist && npm run compile"
+    "compile": "node node_modules/babel/bin/babel.js src --out-dir lib",
+    "build": "npm run dist && npm run compile"
   },
   "repository": {
     "type": "git",
@@ -20,28 +20,28 @@
   },
   "homepage": "https://github.com/CanopyTax/cpr-select",
   "devDependencies": {
-    "autoprefixer-loader": "^1.2.0",
-    "babel": "^5.6.14",
-    "babel-core": "^4.7.13",
-    "babel-loader": "^4.2.0",
-    "css-loader": "^0.9.1",
-    "jasmine-core": "^2.1.3",
-    "jsx-loader": "^0.13.2",
-    "karma": "^0.12.31",
-    "karma-chrome-launcher": "^0.1.7",
-    "karma-jasmine": "^0.3.4",
-    "karma-phantomjs-launcher": "^0.2.0",
-    "karma-sourcemap-loader": "^0.3.5",
-    "karma-webpack": "^1.5.1",
-    "ngmin": "^0.5.0",
-    "ngmin-webpack-plugin": "^0.1.3",
+    "autoprefixer-loader": "1.2.0",
+    "babel": "5.8.23",
+    "babel-core": "4.7.16",
+    "babel-loader": "4.3.0",
+    "css-loader": "0.9.1",
+    "jasmine-core": "2.3.4",
+    "jsx-loader": "0.13.2",
+    "karma": "0.12.37",
+    "karma-chrome-launcher": "0.1.12",
+    "karma-jasmine": "0.3.6",
+    "karma-phantomjs-launcher": "0.2.1",
+    "karma-sourcemap-loader": "0.3.5",
+    "karma-webpack": "1.7.0",
+    "ngmin": "0.5.0",
+    "ngmin-webpack-plugin": "0.1.3",
     "phantomjs-polyfill": "0.0.1",
-    "style-loader": "^0.8.3",
-    "webpack": "^1.4.15"
+    "style-loader": "0.8.3",
+    "webpack": "1.12.2"
   },
   "dependencies": {
-    "lodash": "^3.10.0",
-    "react": "^0.13.3"
+    "lodash": "3.10.1",
+    "react": "0.13.3"
   },
   "optionalDependencies": {
     "canopy-styleguide": "^1.3.2"


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>