### PR TITLE
Fix CON-193. Error tabbing through select with separators

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -191,7 +191,7 @@ const CanopySelect = React.createClass({
 	},
 
 	getViewValue: function(option) {
-		if (option.value === null) return null;
+		if (option.value === null || option.value === undefined) return null;
 		return option.value || option;
 	},
 


### PR DESCRIPTION
https://github.com/CanopyTax/cpr-select/pull/114 created a bug where `option.value` is now allowed to be undefined. But that wasn't being handled correctly. The problem was that when you press the tab key, it causes the component to search the options to see if it can update the value.

See https://sentry.canopytax.com/canopy/workflow-ui/issues/33065/ and https://canopytax.atlassian.net/browse/CON-193