### PR TITLE
resolves BLUE-431: select re-opening after blur

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -165,7 +165,8 @@ export default class CanopySelect extends React.Component {
 
 	onBlur = () => {
 		this.setState({
-			focused: false
+			focused: false,
+			dialogDisplayed: false
     }, () => {
       if (this.props.onBlur) {
 			this.props.onBlur.call(

--- a/src/select.js
+++ b/src/select.js
@@ -11,162 +11,162 @@ function nearest(element, el) {
 
 export default class CanopySelect extends React.Component {
 
-	state = {
-		dialogDisplayed: false,
-		top: 0,
-		focused: false,
-		close: (e) => {
-			if (!nearest(e.target, this.el)) {
-				this.setState({
-					dialogDisplayed: false,
-					focused: false
-				});
-			}
-		}
-	};
+  state = {
+    dialogDisplayed: false,
+    top: 0,
+    focused: false,
+    close: (e) => {
+      if (!nearest(e.target, this.el)) {
+        this.setState({
+          dialogDisplayed: false,
+          focused: false
+        });
+      }
+    }
+  };
 
-	componentWillUnmount() {
-		document.body.removeEventListener('click', this.state.close);
-	}
+  componentWillUnmount() {
+    document.body.removeEventListener('click', this.state.close);
+  }
 
-	componentDidMount() {
-		document.body.addEventListener('click', this.state.close);
-		let index = this.getIndex(this.props.selected);
-		this.setState(() => ({
-			selectedIndex: index === -1 ? 0 : index,
-		}));
-	}
+  componentDidMount() {
+    document.body.addEventListener('click', this.state.close);
+    let index = this.getIndex(this.props.selected);
+    this.setState(() => ({
+      selectedIndex: index === -1 ? 0 : index,
+    }));
+  }
 
-	displayDialog = (e) => {
-		if (this.disabled()) return;
+  displayDialog = (e) => {
+    if (this.disabled()) return;
 
-		this.setState({
-			dialogDisplayed: true
-		})
-	};
+    this.setState({
+      dialogDisplayed: true
+    })
+  };
 
-	getIndex = (key) => {
-		return findIndex(this.props.options, {key: key});
-	};
+  getIndex = (key) => {
+    return findIndex(this.props.options, {key: key});
+  };
 
-	onKeyDown = (e) => {
-		if (this.disabled()) return;
+  onKeyDown = (e) => {
+    if (this.disabled()) return;
 
-		const key = e.which;
-		let selectedIndex = this.state.selectedIndex;
+    const key = e.which;
+    let selectedIndex = this.state.selectedIndex;
 
-		if(key !== 9) {			// tab key
-			e.preventDefault();
-		}
+    if(key !== 9) {      // tab key
+      e.preventDefault();
+    }
 
-		if(key === 13) {				// enter key
-			this.selectItem(selectedIndex)
-		} else if(key === 38) { // up key
-			if (selectedIndex <= 0) {
-				this.setState({
-					dialogDisplayed: true,
-				});
-			} else {
-				this.setState({
-					dialogDisplayed: true,
-					selectedIndex: selectedIndex - 1
-				});
-			}
+    if(key === 13) {        // enter key
+      this.selectItem(selectedIndex)
+    } else if(key === 38) { // up key
+      if (selectedIndex <= 0) {
+        this.setState({
+          dialogDisplayed: true,
+        });
+      } else {
+        this.setState({
+          dialogDisplayed: true,
+          selectedIndex: selectedIndex - 1
+        });
+      }
 
-		} else if (key === 40) { // down key
+    } else if (key === 40) { // down key
 
-			if (selectedIndex === this.props.options.length - 1) {
-				this.setState({
-					dialogDisplayed: true
-				});
-			} else {
-				this.setState({
-					dialogDisplayed: true,
-					selectedIndex: selectedIndex + 1
-				});
-			}
-		} else if(key === 27) { // escape key
-			this.setState({
-				dialogDisplayed: false
-			});
-		} else {								// all other keys
-			this.highlightByText(e.which);
-		}
-	};
+      if (selectedIndex === this.props.options.length - 1) {
+        this.setState({
+          dialogDisplayed: true
+        });
+      } else {
+        this.setState({
+          dialogDisplayed: true,
+          selectedIndex: selectedIndex + 1
+        });
+      }
+    } else if(key === 27) { // escape key
+      this.setState({
+        dialogDisplayed: false
+      });
+    } else {                // all other keys
+      this.highlightByText(e.which);
+    }
+  };
 
-	triggerItemChange = () => {
-		if (this.props.onChange) {
-			this.props.onChange.call(
-				null,
-				this.props.options[this.state.selectedIndex].key,
-				this.props.options[this.state.selectedIndex],
-				this.state.selectedIndex
-			);
-		}
-	};
+  triggerItemChange = () => {
+    if (this.props.onChange) {
+      this.props.onChange.call(
+        null,
+        this.props.options[this.state.selectedIndex].key,
+        this.props.options[this.state.selectedIndex],
+        this.state.selectedIndex
+      );
+    }
+  };
 
-	selectItem = (index, e) => {
-		if (this.disabled()) return;
+  selectItem = (index, e) => {
+    if (this.disabled()) return;
 
-		setTimeout(() => {
-			this.setState({
-				selectedIndex: index,
-				focused: true,
-				dialogDisplayed: false
-			});
-			setTimeout(this.triggerItemChange);
-		});
-	};
+    setTimeout(() => {
+      this.setState({
+        selectedIndex: index,
+        focused: true,
+        dialogDisplayed: false
+      });
+      setTimeout(this.triggerItemChange);
+    });
+  };
 
-	positionDialogAndGetTop = (options, index, maxHeight) => {
-		const distanceFromEnd = options.length - index;
-		const numVisibleOptions = Math.floor(maxHeight / 36);
-		const numSurroundingOptions = Math.floor((numVisibleOptions - 1) / 2);
-		const unusedPixels = maxHeight % 36;
+  positionDialogAndGetTop = (options, index, maxHeight) => {
+    const distanceFromEnd = options.length - index;
+    const numVisibleOptions = Math.floor(maxHeight / 36);
+    const numSurroundingOptions = Math.floor((numVisibleOptions - 1) / 2);
+    const unusedPixels = maxHeight % 36;
 
-		if (index > numSurroundingOptions && distanceFromEnd < numSurroundingOptions + 1) {
-			// Bottom 5
-			if (options.length < numVisibleOptions) {
-				// Dialog doesn't have a scroll
-				return -2 + (36 * index * -1 - 10) + "px";
-			} else {
-				// Dialog has a scroll
-				this.positionDialog(index, maxHeight);
-				const start = (maxHeight / -2) - 15;
-				return start - (numSurroundingOptions - distanceFromEnd) * 36 + "px";
-			}
-		} else if (index > numSurroundingOptions) {
-			// Middle
-			this.positionDialog(index, maxHeight);
-			return (maxHeight / -2) - 0.0075 * maxHeight;
-		} else {
-			// Top 5
-			return -1 + (36 * index * -1 - 10) + "px";
-		}
-	};
+    if (index > numSurroundingOptions && distanceFromEnd < numSurroundingOptions + 1) {
+      // Bottom 5
+      if (options.length < numVisibleOptions) {
+        // Dialog doesn't have a scroll
+        return -2 + (36 * index * -1 - 10) + "px";
+      } else {
+        // Dialog has a scroll
+        this.positionDialog(index, maxHeight);
+        const start = (maxHeight / -2) - 15;
+        return start - (numSurroundingOptions - distanceFromEnd) * 36 + "px";
+      }
+    } else if (index > numSurroundingOptions) {
+      // Middle
+      this.positionDialog(index, maxHeight);
+      return (maxHeight / -2) - 0.0075 * maxHeight;
+    } else {
+      // Top 5
+      return -1 + (36 * index * -1 - 10) + "px";
+    }
+  };
 
-	positionDialog = (index, maxHeight) => {
-		setTimeout(() => {
-			let menuDialog = this.el.querySelector(".cp-select__menu");
-			if (menuDialog) {
-				const dialogHeightImpact = maxHeight / 2 - 8;
-				menuDialog.scrollTop = (36 * index - dialogHeightImpact);
-			}
-		});
-	};
+  positionDialog = (index, maxHeight) => {
+    setTimeout(() => {
+      let menuDialog = this.el.querySelector(".cp-select__menu");
+      if (menuDialog) {
+        const dialogHeightImpact = maxHeight / 2 - 8;
+        menuDialog.scrollTop = (36 * index - dialogHeightImpact);
+      }
+    });
+  };
 
-	focusSelect = () => {
-		if (!this.state.focused) {
-			this.setState({
-				focused: true
-			});
-		}
-	};
+  focusSelect = () => {
+    if (!this.state.focused) {
+      this.setState({
+        focused: true
+      });
+    }
+  };
 
-	onBlur = () => {
-		this.setState({
-			focused: false,
-			dialogDisplayed: false
+  onBlur = () => {
+    this.setState({
+      focused: false,
+      dialogDisplayed: false
 
     }, () => {
       if (this.props.onBlur) {


### PR DESCRIPTION
Resolves BLUE-431. Previously selected `cpr-select` doesn't re-open when using arrow keys to navigate within new `cpr-select`

**BEFORE:** 
https://jumpshare.com/v/A3IHv2iD2dfIyMFzV0fK

**AFTER:**
![select](https://user-images.githubusercontent.com/19310727/45651303-517bf280-ba8e-11e8-82bf-7826a0943562.gif)
